### PR TITLE
Cleaned up the overlap between inviteOnly/topicStatus and _modes. Fix…

### DIFF
--- a/includes/channel.hpp
+++ b/includes/channel.hpp
@@ -30,8 +30,6 @@ class Channel
 		std::vector<Client*>	_operators;
 		std::vector<Client*>	_invitelist;
 		size_t		_userlimit;
-		bool		_inviteOnly;
-		bool		_topicStatus;
 
 		bool	check_operator_priv(Client *client);
 
@@ -57,8 +55,6 @@ class Channel
 		bool					get_topicStatus() const;
 
         //Setters
-		bool	set_inviteOnly(bool flag);
-		bool	set_topicStatus(bool flag);
 		int		set_modes(uint8_t newmodes);
 		int 	unset_mode(uint8_t newmodes);
 		int		set_password(std::string password);
@@ -79,6 +75,7 @@ class Channel
 		int		client_was_in_channel(Client* client);
 		int		client_is_operator(Client* client);
 		int		addInviteList(Client* client);
+		std::string	string_modes(void) const;
 
 		//Others (User actions)
 		int		leave_channel(Client* client);

--- a/srcs/channel.cpp
+++ b/srcs/channel.cpp
@@ -10,13 +10,12 @@ Channel::Channel(std::string name, Client* creator, Server* server) : _server(se
 	_name = name;
 	_topic = "";
 	_password = "";
-	_modes = MODE_LIM;
+	_modes = MODE_TOP;
 	_userlimit = server->get_config().get_maxClients();
 	_owner = creator;
 	_clients = std::vector<Client*>{creator};
 	_partedClients = std::vector<Client*>{};
 	_operators = std::vector<Client*>{creator};
-	_inviteOnly = false;
 }
 
 Channel::Channel(const Channel &copy) {
@@ -40,7 +39,6 @@ Channel &Channel::operator=(const Channel &copy)
 	_server = copy._server;
 	_owner = copy._owner;
 	_invitelist = copy._invitelist;
-	_inviteOnly = copy._inviteOnly;
 	return(*this);
 }
 
@@ -98,7 +96,7 @@ Client*	Channel::get_owner() const
 
 bool	Channel::get_inviteStatus() const
 {
-	return (_inviteOnly);
+	return (_modes & MODE_INV);
 }
 
 bool	Channel::get_topicStatus() const
@@ -135,18 +133,6 @@ int Channel::set_limit(int limit)
 int	Channel::set_topic(std::string topic)
 {
 	_topic = topic;
-	return (SUCCESS);
-}
-
-bool	Channel::set_topicStatus(bool flag)
-{
-	_topicStatus = flag;
-	return (SUCCESS);
-}
-
-bool	Channel::set_inviteOnly(bool flag)
-{
-	_inviteOnly = flag;
 	return (SUCCESS);
 }
 
@@ -372,4 +358,19 @@ int		Channel::addInviteList(Client *client)
 		return SUCCESS;
 	}
 	return FAILURE;
+}
+
+std::string	Channel::string_modes(void) const
+{
+	std::string mode_str = "";
+
+	if (_modes & MODE_INV)
+		mode_str += "i";
+	if (_modes & MODE_KEY)
+		mode_str += "k";
+	if (_modes & MODE_LIM)
+		mode_str += "l";
+	if (_modes & MODE_TOP)
+		mode_str += "t";
+	return mode_str;
 }

--- a/srcs/client.cpp
+++ b/srcs/client.cpp
@@ -144,7 +144,6 @@ int			Client::add_channel(Channel *channel)
 	if (!is_in_channel(channel->get_name()))
 	{
 		_channelList.push_back(channel);
-		std::cout << _channelList.front()->get_name() << std::endl;
 		return SUCCESS;
 	}
 	return FAILURE;
@@ -188,7 +187,6 @@ void			Client::leave_all_channels(void)
 	}
 	for (std::vector<Channel*>::iterator iter = _partedChannels.begin(); iter != _partedChannels.end(); iter = _partedChannels.begin())
 	{
-		std::cout << (*iter)->get_name() << std::endl;
 		(*iter)->remove_parted_client(this);
 		_partedChannels.erase(iter);
 		if ((*iter)->get_clients().empty()  && (*iter)->get_partedClients().empty())

--- a/srcs/client.cpp
+++ b/srcs/client.cpp
@@ -141,14 +141,12 @@ void	Client::set_registered(bool state) {
 
 int			Client::add_channel(Channel *channel)
 {
-	std::cout << "Client::add_channel()" << std::endl;
 	if (!is_in_channel(channel->get_name()))
 	{
 		_channelList.push_back(channel);
 		std::cout << _channelList.front()->get_name() << std::endl;
 		return SUCCESS;
 	}
-	std::cout << "Client already in channel" << std::endl;
 	return FAILURE;
 }
 

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -6,7 +6,7 @@
 /*   By: mteerlin <mteerlin@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/09 15:37:20 by mteerlin      #+#    #+#                 */
-/*   Updated: 2024/03/29 21:00:32 by mteerlin      ########   odam.nl         */
+/*   Updated: 2024/03/30 19:08:51 by mteerlin      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ static bool	pass_channel_modes(Client *client, Channel *channel, Server *server)
 		send_response_message(client, ERR_CHANNELISFULL, client->get_nickname() + "" + channel->get_name(), server);
 		return false;
 	}
-	if (channel->get_modes() & MODE_INV && !channel->is_invited(client)) //Add a check to see if the client is on the invite list if JOIN is used alongside INVITE
+	if (channel->get_modes() & MODE_INV && channel->is_invited(client) < 0) //Add a check to see if the client is on the invite list if JOIN is used alongside INVITE
 	{
 		send_response_message(client, ERR_INVITEONLYCHAN, client->get_nickname() + "" + channel->get_name(), server);
 		return false;
@@ -43,8 +43,6 @@ static bool	check_channel_mask(Client *client, std::string channelName, Server *
 
 static bool check_channel_key(Client *client, Channel *channel, std::string key, Server *server)
 {
-	std::cout << "\t" << (channel->get_modes() & MODE_KEY) << " | " << (!channel->get_password().empty()) << " | " << key << " == " << channel->get_password() << std::endl;
-
 	if (channel->get_modes() & MODE_KEY && !channel->get_password().empty() && key != channel->get_password())
 	{
 		send_response_message(client, ERR_BADCHANNELKEY, client->get_nickname() + " " + channel->get_name(), server);

--- a/srcs/commands/modes.cpp
+++ b/srcs/commands/modes.cpp
@@ -6,7 +6,7 @@
 /*   By: ahorling <ahorling@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 16:41:43 by ahorling      #+#    #+#                 */
-/*   Updated: 2024/03/30 21:09:32 by mteerlin      ########   odam.nl         */
+/*   Updated: 2024/03/30 21:11:59 by mteerlin      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,13 +21,11 @@
 
 std::string	toggleInviteOnly(char toggle, Channel* channel)
 {
-	std::cout << "toggleInviteOnly()" << std::endl;
 	if (toggle == '+' && channel->get_inviteStatus() == true)
 		return "";
 	else if (toggle == '+' && channel->get_inviteStatus() == false)
 	{
 		channel->set_modes(MODE_INV);
-		std::cout << "INVITE MODE SET" << std::endl;
 		return ("+i");
 	}
 	else if (toggle == '-' && channel->get_inviteStatus() == true)

--- a/srcs/commands/modes.cpp
+++ b/srcs/commands/modes.cpp
@@ -6,7 +6,7 @@
 /*   By: ahorling <ahorling@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 16:41:43 by ahorling      #+#    #+#                 */
-/*   Updated: 2024/03/30 19:05:55 by mteerlin      ########   odam.nl         */
+/*   Updated: 2024/03/30 21:09:32 by mteerlin      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -194,52 +194,12 @@ void	change_mode(Client *client, std::vector<std::string> tokens, Server *server
 	std::map<std::string, Channel*>::iterator currentChannel;
 
 	if (server->get_channelList()->empty())
-	{
-		send_response_message(client, ERR_NOSUCHCHANNEL, tokens[1], server);
-		return;
-	}
+		return send_response_message(client, ERR_NOSUCHCHANNEL, tokens[1], server);
 	currentChannel = server->get_channelList()->find(tokens[1]);
 	if (currentChannel == server->get_channelList()->end())
-	{
-		send_response_message(client, ERR_NOSUCHCHANNEL, tokens[1], server);
-		return;
-	}
+		return send_response_message(client, ERR_NOSUCHCHANNEL, tokens[1], server);
 	if (currentChannel->second->client_is_operator(client) < 0)
-	{
-		send_response_message(client, ERR_CHANOPRIVSNEEDED, tokens[1], server);
-		return;
-	}
-
-	// if (tokens.size() == 3)
-	// {
-	// 	modesList = split_modes(tokens[2]);
-	// 	if (modesList.empty())
-	// 		return;
-	// 	for (std::map<char, char>::iterator modeitr = modesList.begin(); modeitr != clientList.end(); ++modeitr)
-	// 	{
-	// 		switch (modeitr->first)
-	// 		{
-	// 			case "i":
-	// 				toggleInviteOnly(modeitr->second, currentChannel->second);
-	// 				break;
-	// 			case "t":
-	// 				toggleTopicRestriction(modeitr->second, currentChannel->second);
-	// 				break;
-	// 			case "k":
-	// 				changePassword(modeitr->second, nullptr, currentChannel->second);
-	// 				break;
-	// 			case "l":
-	// 				setUserLimit(modeitr->second, nullptr, currentChannel->second);
-	// 				break;
-	// 			case "o":
-	// 				promoteOperator(modeitr->second, nullptr, currentChannel->second);
-	// 				break;
-	// 			default:
-	// 				send_response_message(client, ERR_UNKNOWNMODE, modeitr->first);
-	// 		}
-	// 	}
-	// 	return;
-	// }
+		return send_response_message(client, ERR_CHANOPRIVSNEEDED, tokens[1], server);
 
 	if (tokens.size() >= 3)
 	{

--- a/srcs/commands/modes.cpp
+++ b/srcs/commands/modes.cpp
@@ -6,7 +6,7 @@
 /*   By: ahorling <ahorling@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 16:41:43 by ahorling      #+#    #+#                 */
-/*   Updated: 2024/03/30 17:10:38 by mteerlin      ########   odam.nl         */
+/*   Updated: 2024/03/30 19:05:55 by mteerlin      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,17 +21,17 @@
 
 std::string	toggleInviteOnly(char toggle, Channel* channel)
 {
+	std::cout << "toggleInviteOnly()" << std::endl;
 	if (toggle == '+' && channel->get_inviteStatus() == true)
 		return "";
 	else if (toggle == '+' && channel->get_inviteStatus() == false)
 	{
-		channel->set_inviteOnly(true);
 		channel->set_modes(MODE_INV);
+		std::cout << "INVITE MODE SET" << std::endl;
 		return ("+i");
 	}
 	else if (toggle == '-' && channel->get_inviteStatus() == true)
 	{
-		channel->set_inviteOnly(false);
 		channel->unset_mode(MODE_INV);
 		return ("-i");
 	}
@@ -46,13 +46,11 @@ std::string	toggleTopicRestriction(char toggle, Channel* channel)
 		return "";
 	else if (toggle == '+' && channel ->get_topicStatus() == false)
 	{
-		channel->set_topicStatus(true);
 		channel->set_modes(MODE_TOP);
 		return ("+t");
 	}
 	else if (toggle == '-' && channel ->get_topicStatus() == true)
 	{
-		channel->set_topicStatus(false);
 		channel->unset_mode(MODE_TOP);
 		return ("-t");
 	}
@@ -142,6 +140,15 @@ std::string	 promoteOperator(char toggle, std::string toPromote, Channel* channe
 }
 
 //END COMMAND FUNCTIONS
+static bool contains_flag(char flag, std::vector<std::pair<char, char>> modesList)
+{
+	for (std::vector<std::pair<char, char>>::iterator iter = modesList.begin(); iter != modesList.end(); iter++)
+	{
+		if (iter->first == flag)
+			return true;
+	}
+	return false;
+}
 
 std::vector<std::pair<char, char>>	split_modes(std::string tokens)
 {
@@ -159,8 +166,10 @@ std::vector<std::pair<char, char>>	split_modes(std::string tokens)
 		}
 		else
 			flag = tokens[i];
-		if (sign != '0' && flag != '0')
+		if (sign != '0' && flag != '0' && !contains_flag(flag, modesList))
+		{
 			modesList.push_back(std::make_pair(flag, sign));
+		}
 	}
 	return (modesList);
 }
@@ -173,9 +182,11 @@ void	change_mode(Client *client, std::vector<std::string> tokens, Server *server
 	std::string modeChanges;
 
 	//If there are only 2 passed paramaters in the command, send the current list of modes. if channel send channel commands
-	if (tokens.size() == 2)
+	if (tokens.size() < 2 || (tokens[1][0] != '#' && tokens[1][0] != '&'))
+		return ;
+	if (tokens.size() == 2 || (tokens.size() == 3 && tokens[3] == ":"))
 	{
-		server->msg_to_client(client->get_fd(), ":" + client->get_nickname() + "!" + client->get_hostmask() + " " + tokens[1] + " :" + server->get_config().get_channelModes());
+		server->msg_to_client(client->get_fd(), ":" + client->get_nickname() + "!" + client->get_hostmask() + " MODE " + tokens[1] + " :" + server->get_channel(tokens[1])->string_modes());
 		return;
 	}
 
@@ -285,7 +296,7 @@ void	change_mode(Client *client, std::vector<std::string> tokens, Server *server
 	std::string finalMessage = ":" + client->get_nickname() + "!" + client->get_hostmask();
 	int i = 3;
 	
-	finalMessage += (" MODE " + modeChanges);
+	finalMessage += (" MODE " + tokens[1] + " :" + modeChanges);
 	while(tokens[i] != *tokens.end())
 	{
 		finalMessage += (" " + tokens[i]);

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -6,7 +6,7 @@
 /*   By: mteerlin <mteerlin@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/14 18:06:52 by mteerlin      #+#    #+#                 */
-/*   Updated: 2024/03/04 17:48:32 by mteerlin      ########   odam.nl         */
+/*   Updated: 2024/03/30 21:13:47 by mteerlin      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,6 @@ static std::string	string_nicknames(std::vector<Client*> clientList, Channel *ch
 			prefix = "@";
 		nickList += prefix + (*iter)->get_nickname();
 	}
-	std::cout << nickList << std::endl;
 	return nickList;
 }
 

--- a/srcs/commands/topic.cpp
+++ b/srcs/commands/topic.cpp
@@ -6,7 +6,7 @@
 /*   By: mteerlin <mteerlin@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/28 12:20:11 by mteerlin      #+#    #+#                 */
-/*   Updated: 2024/03/29 19:47:12 by mteerlin      ########   odam.nl         */
+/*   Updated: 2024/03/30 21:13:54 by mteerlin      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,6 @@ static void	change_topic(Client *client, Channel *channel, std::string newTopic,
 {
 	std::string reply;
 
-	std::cout << (channel->get_modes() & MODE_TOP) << std::endl;
 	if ((channel->get_modes() & MODE_TOP) && channel->client_is_operator(client) < 0)
 		return send_response_message(client, ERR_CHANOPRIVSNEEDED, channel->get_name(), server);
 	channel->set_topic(newTopic);


### PR DESCRIPTION
Cleaned up overlap between inviteOnly/topicStatus and _modes. Fixeded a bug allowing uninvited people to join an invite only channel. Added a check to ignore non-channels in MODE. fixed 'MODE <Channel>' and 'MODE <channel> :' to display the modes of current channel, rather then the default modes configuration.